### PR TITLE
Minor Update to Readme file to mention passing a string to .rejects

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ Returns a resolved bluebird promise with given value
 
 **.rejects(value)**
 
-Returns a rejected bluebird promise with the given value
+Returns a rejected bluebird promise with the given value.
+
+*Note: If the given value is a String, that string will be wrapped in an Error object and will be on the message property.*
 
 ## Inspiration
 


### PR DESCRIPTION
- Added note about `rejects` returned value when a `String` is passed in
