### PR TITLE
Add in auto unwrapping of promises for spies

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ This package has peerDependencies of the following:
 ```js
 // Require in the libs
 var sinon = require('sinon'),
-  sinonBluebird = require('sinon-bluebird');
+  sinonBluebird = require('sinon-bluebird'),
+  BPromise = require('bluebird');
 
+////// -- Stubs Usage -- //////
 // Create an example function
 var obj = {
   foo: function foo() {
@@ -65,7 +67,48 @@ obj.foo.restore();
 
 // Original method back to normal
 obj.foo(); // === 'bar'
+////// -- End Stubs Usage -- //////
 
+////// -- Spies Usage -- //////
+
+var obj = {
+  returnMethod: function (val) {
+    return BPromise.resolve(val);
+  },
+  paramMethod: function (val, prom, val2) {
+    return true;
+  }
+}
+
+// Return methods
+var spy = sinon.spy(obj, 'returnMethod');
+
+obj.returnMethod('Hello'); //execute the test function
+spy.returnedPromise('Hello'); // === true
+
+obj.returnMethod('World'); //execute the test function a second time
+spy.alwaysReturnedPromise('Hello'); // === false
+
+spy.restore();
+
+//Called With methods
+spy = sinon.spy(obj, 'paramMethod');
+
+obj.paramMethod(BPromise.resolve('Hello')); //pass in a promise
+spy.calledWithPromise('Hello'); // === true
+obj.paramMethod.reset(); //reset spy
+
+/* Pass in a promise mixed with regular values
+ * Note the rejected promise passed in, any rejected promise will possibly show up in console.log
+ * due to how bluebird reports possibly unhandled exceptions (even though in this case we are
+ * intentionally passing in a rejected promise)
+*/
+obj.paramMethod('Hello', BPromise.reject('World'), '!');
+spy.calledWithMatch('Hello', 'World', String);  // === true (match allows for comparison by type too!)
+
+obj.paramMethod.restore() //restore the original method back
+
+////// -- End Spies Usage -- //////
 ```
 
 ## API
@@ -81,6 +124,50 @@ Returns a resolved bluebird promise with the given value
 Returns a rejected bluebird promise with the given value.
 
 *Note: If the given value is a String, that string will be wrapped in an Error object and will be on the message property.*
+
+### Spies
+
+#### Return Value Methods
+
+*Promises cannot be in a pending state otherwise an error will be thrown.*
+
+**.returnedPromise(value)**
+
+Identical to sinon `.returned()` except it automatically unwraps the bluebird promise(if a promise is returned) and compares directly to the unwrapped value.
+
+**.alwaysReturnedPromise(value)**
+
+Identical to sinon `.alwaysReturned()` except it automatically unwraps the bluebird promise(if a promise is returned) and compares directly to the unwrapped value.
+
+#### Called With Methods
+
+*The promise (or promises) can be anywhere in the list of arguments passed into the spied on function or none at all.*
+
+*Promises cannot be in a pending state otherwise an error will be thrown.*
+
+**.calledWithPromise(value, ...)**
+
+Identical to sinon `.calledWith()` except it automatically unwraps the bluebird promise(if a promise is passed in) and compares directly to the unwrapped value.
+
+**.calledWithMatchPromise(value, ...)**
+
+Identical to sinon `.calledWithMatch()` except it automatically unwraps the bluebird promise(if a promise is passed in) and compares directly to the unwrapped value.
+
+**.alwaysCalledWithPromise(value, ...)**
+
+Identical to sinon `.alwaysCalledWith()` except it automatically unwraps the bluebird promise(if a promise is passed in) and compares directly to the unwrapped value.
+
+**.alwaysCalledWithMatchPromise(value, ...)**
+
+Identical to sinon `.alwaysCalledWithMatch()` except it automatically unwraps the bluebird promise(if a promise is passed in) and compares directly to the unwrapped value.
+
+**.calledWithExactlyPromise(value, ...)**
+
+Identical to sinon `.calledWithExactly()` except it automatically unwraps the bluebird promise(if a promise is passed in) and compares directly to the unwrapped value.
+
+**.alwaysCalledWithExactlyPromise(value, ...)**
+
+Identical to sinon `.alwaysCalledWithExactly()` except it automatically unwraps the bluebird promise(if a promise is passed in) and compares directly to the unwrapped value.
 
 ## Inspiration
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Returns a rejected bluebird promise with the given value.
 
 ### Spies
 
-All spy methods are identical to `sinon`'s version except it automatically unwraps the bluebird promise (if a promise is returned) and compares directly to the unwrapped value. We append the word `Promise` to each method to denote it unwraps a promise.
+All spy methods are identical to [sinons](http://sinonjs.org/docs/#spies-api) version except it automatically unwraps the bluebird promise (if a promise is returned) and compares directly to the unwrapped value. We append the word `Promise` to each method to denote it unwraps a promise.
 
 #### Return Value Methods
 

--- a/README.md
+++ b/README.md
@@ -127,17 +127,16 @@ Returns a rejected bluebird promise with the given value.
 
 ### Spies
 
+All spy methods are identical to `sinon`'s version except it automatically unwraps the bluebird promise (if a promise is returned) and compares directly to the unwrapped value. We append the word `Promise` to each method to denote it unwraps a promise.
+
 #### Return Value Methods
 
 *Promises cannot be in a pending state otherwise an error will be thrown.*
 
 **.returnedPromise(value)**
 
-Identical to sinon `.returned()` except it automatically unwraps the bluebird promise(if a promise is returned) and compares directly to the unwrapped value.
-
 **.alwaysReturnedPromise(value)**
 
-Identical to sinon `.alwaysReturned()` except it automatically unwraps the bluebird promise(if a promise is returned) and compares directly to the unwrapped value.
 
 #### Called With Methods
 
@@ -147,27 +146,15 @@ Identical to sinon `.alwaysReturned()` except it automatically unwraps the blueb
 
 **.calledWithPromise(value, ...)**
 
-Identical to sinon `.calledWith()` except it automatically unwraps the bluebird promise(if a promise is passed in) and compares directly to the unwrapped value.
-
 **.calledWithMatchPromise(value, ...)**
-
-Identical to sinon `.calledWithMatch()` except it automatically unwraps the bluebird promise(if a promise is passed in) and compares directly to the unwrapped value.
 
 **.alwaysCalledWithPromise(value, ...)**
 
-Identical to sinon `.alwaysCalledWith()` except it automatically unwraps the bluebird promise(if a promise is passed in) and compares directly to the unwrapped value.
-
 **.alwaysCalledWithMatchPromise(value, ...)**
-
-Identical to sinon `.alwaysCalledWithMatch()` except it automatically unwraps the bluebird promise(if a promise is passed in) and compares directly to the unwrapped value.
 
 **.calledWithExactlyPromise(value, ...)**
 
-Identical to sinon `.calledWithExactly()` except it automatically unwraps the bluebird promise(if a promise is passed in) and compares directly to the unwrapped value.
-
 **.alwaysCalledWithExactlyPromise(value, ...)**
-
-Identical to sinon `.alwaysCalledWithExactly()` except it automatically unwraps the bluebird promise(if a promise is passed in) and compares directly to the unwrapped value.
 
 ## Inspiration
 

--- a/index.js
+++ b/index.js
@@ -61,8 +61,7 @@ sinon.spy.getPromiseCall = function (i) {
 
   //Check for and unwrap the return value if it's a promise
   var returnVal = this.returnValues[i];
-  if (returnVal &&
-    typeof returnVal.isFulfilled === 'function') {
+  if (returnVal && typeof returnVal.isFulfilled === 'function') {
     if (returnVal.isFulfilled()) {
       returnVal = returnVal.value();
     }

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function RejectBPromise(value) {
   this.value = value;
 }
 
-// Go through all Bluebird and Wrap each method on the new RejectBPromise class
+// Go through all Bluebird and wrap each method on the new RejectBPromise class
 Object.keys(BPromise.prototype).map(function (key) {
   RejectBPromise.prototype[key] = function () {
     var prom = new BPromise.reject(this.value);
@@ -27,7 +27,7 @@ Object.keys(BPromise.prototype).map(function (key) {
 function rejects(value) {
   this.rejectBPromise = true;
 
-  //if its a string, wrap it in an error object
+  //if it's a string, wrap it in an error object
   if (typeof value === "string") {
     value = new Error(value);
   }
@@ -38,8 +38,8 @@ function rejects(value) {
 // Attach rejects function to sinon
 sinon.stub.rejects = sinon.behavior.rejects = rejects;
 
-//Special getCall method that check of existence of promises in return value and args,
-//if found, then unwraps them uses their value inplace of the promise
+//Special getCall method that checks for existence of promises in return value and args.
+//If found, then unwraps them using their value in place of the promise
 sinon.spy.getPromiseCall = function (i) {
   if (i < 0 || i >= this.callCount) {
     return null;
@@ -59,7 +59,7 @@ sinon.spy.getPromiseCall = function (i) {
     }
   }
 
-  //Check for and unwrap the return value if its a promise
+  //Check for and unwrap the return value if it's a promise
   var returnVal = this.returnValues[i];
   if (returnVal &&
     typeof returnVal.isFulfilled === 'function') {
@@ -120,5 +120,5 @@ sinon.spy.delegateToCallsPromise("alwaysCalledWithMatchPromise", false, "calledW
 sinon.spy.delegateToCallsPromise("calledWithExactlyPromise", true, "calledWithExactly");
 sinon.spy.delegateToCallsPromise("alwaysCalledWithExactlyPromise", false, "calledWithExactly");
 
-// Expore Sinon
+// Export Sinon
 module.exports = exports = sinon;

--- a/package.json
+++ b/package.json
@@ -5,13 +5,23 @@
   "engines": {
     "node": ">=0.10 <0.13"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/L7labs/sinon-bluebird.git"
-  },
   "scripts": {
     "test": "grunt test"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/L7labs/sinon-bluebird"
+  },
+  "keywords": [
+    "bluebird",
+    "sinon"
+  ],
+  "author": "Todd Bluhm",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/L7Labs/sinon-bluebird/issues"
+  },
+  "homepage": "https://github.com/L7Labs/sinon-bluebird",
   "peerDependencies": {
     "sinon": "1.x",
     "bluebird": "2.x"

--- a/test/tests.js
+++ b/test/tests.js
@@ -17,7 +17,7 @@ describe('Sinon-Bluebird', function () {
       reject: function reject() {
         return BPromise.reject('Error');
       },
-      syncronous: function syncronous() {
+      synchronous: function synchronous() {
         return 'Some string';
       }
     };
@@ -32,7 +32,7 @@ describe('Sinon-Bluebird', function () {
         this.stub2 = sinon.stub(obj, 'reject').resolves('Stubbed Success 2');
 
         //stub example 3 (return array that can be spread)
-        sinon.stub(obj, 'syncronous').resolves(['Stubbed Success', 3]);
+        sinon.stub(obj, 'synchronous').resolves(['Stubbed Success', 3]);
       });
 
       it('should resolve \'success\' method of obj with \'Stubbed Success\' message',
@@ -53,10 +53,10 @@ describe('Sinon-Bluebird', function () {
             });
         });
 
-      it('should resolve \'syncronous\' method of obj with multiple values: \'Stubbed Success\'' +
+      it('should resolve \'synchronous\' method of obj with multiple values: \'Stubbed Success\'' +
         ' and \'3\'',
         function () {
-          return obj.syncronous()
+          return obj.synchronous()
             .spread(function (msg, count) {
               msg.should.equal('Stubbed Success');
               count.should.equal(3);
@@ -68,7 +68,7 @@ describe('Sinon-Bluebird', function () {
         //restore all the functions individually
         obj.success.restore();
         obj.reject.restore();
-        obj.syncronous.restore();
+        obj.synchronous.restore();
       });
     });
 
@@ -80,7 +80,7 @@ describe('Sinon-Bluebird', function () {
         //stub examples
         this.sandbox.stub(obj, 'success').rejects(new Error('Stubbed Failure'));
         this.sandbox.stub(obj, 'reject').rejects('Stubbed Failure 2');
-        this.sandbox.stub(obj, 'syncronous').rejects('Stubbed Failure 3');
+        this.sandbox.stub(obj, 'synchronous').rejects('Stubbed Failure 3');
       });
 
       it('should reject \'success\' method of obj with Error\'Stubbed Failure\' message',
@@ -103,9 +103,9 @@ describe('Sinon-Bluebird', function () {
             });
         });
 
-      it('should reject \'syncronous\' method of obj with Error \'Stubbed Failure 3\' message',
+      it('should reject \'synchronous\' method of obj with Error \'Stubbed Failure 3\' message',
         function () {
-          return obj.syncronous()
+          return obj.synchronous()
             .catch(function (msg) {
               msg.should.be.Error;
               msg.message.should.equal('Stubbed Failure 3');

--- a/test/tests.js
+++ b/test/tests.js
@@ -3,115 +3,263 @@ var should = require('should'),
   sinon = require('sinon'),
   sinonBluebird = require('../');
 
+//Squelch any possibly unhandeled promises logs
+BPromise.onPossiblyUnhandledRejection(function (e, promise) {});
+
 describe('Sinon-Bluebird', function () {
 
-  ///// Test Methods
-  var obj = {
-    success: function success() {
-      return BPromise.resolve('Success');
-    },
-    reject: function reject() {
-      return BPromise.reject('Error');
-    },
-    syncronous: function syncronous() {
-      return 'Some string';
-    }
-  };
+  describe('Stubs', function () {
+    ///// Test Methods
+    var obj = {
+      success: function success() {
+        return BPromise.resolve('Success');
+      },
+      reject: function reject() {
+        return BPromise.reject('Error');
+      },
+      syncronous: function syncronous() {
+        return 'Some string';
+      }
+    };
 
-  describe('Resolve stubs', function () {
-    before(function () {
-      //stub example 1
-      this.stub = sinon.stub(obj, 'success');
-      this.stub.resolves('Stubbed Success');
+    describe('Resolve stubs', function () {
+      before(function () {
+        //stub example 1
+        this.stub = sinon.stub(obj, 'success');
+        this.stub.resolves('Stubbed Success');
 
-      //stub example 2
-      this.stub2 = sinon.stub(obj, 'reject').resolves('Stubbed Success 2');
+        //stub example 2
+        this.stub2 = sinon.stub(obj, 'reject').resolves('Stubbed Success 2');
 
-      //stub example 3 (return array that can be spread)
-      sinon.stub(obj, 'syncronous').resolves(['Stubbed Success', 3]);
+        //stub example 3 (return array that can be spread)
+        sinon.stub(obj, 'syncronous').resolves(['Stubbed Success', 3]);
+      });
+
+      it('should resolve \'success\' method of obj with \'Stubbed Success\' message',
+        function () {
+          return obj.success()
+            .then(function (msg) {
+              msg.should.equal('Stubbed Success');
+              return true;
+            });
+        });
+
+      it('should resolve \'reject\' method of obj with \'Stubbed Success 2\' message',
+        function () {
+          return obj.reject()
+            .then(function (msg) {
+              msg.should.equal('Stubbed Success 2');
+              return true;
+            });
+        });
+
+      it('should resolve \'syncronous\' method of obj with multiple values: \'Stubbed Success\'' +
+        ' and \'3\'',
+        function () {
+          return obj.syncronous()
+            .spread(function (msg, count) {
+              msg.should.equal('Stubbed Success');
+              count.should.equal(3);
+              return true;
+            });
+        });
+
+      after(function () {
+        //restore all the functions individually
+        obj.success.restore();
+        obj.reject.restore();
+        obj.syncronous.restore();
+      });
     });
 
-    it('should resolve \'success\' method of obj with \'Stubbed Success\' message',
-      function () {
-        return obj.success()
-          .then(function (msg) {
-            msg.should.equal('Stubbed Success');
-            return true;
-          });
+    describe('Reject stubs', function () {
+      before(function () {
+        //create a sinon sandbox to show how to easily restore funcs
+        this.sandbox = sinon.sandbox.create();
+
+        //stub examples
+        this.sandbox.stub(obj, 'success').rejects(new Error('Stubbed Failure'));
+        this.sandbox.stub(obj, 'reject').rejects('Stubbed Failure 2');
+        this.sandbox.stub(obj, 'syncronous').rejects('Stubbed Failure 3');
       });
 
-    it('should resolve \'reject\' method of obj with \'Stubbed Success 2\' message',
-      function () {
-        return obj.reject()
-          .then(function (msg) {
-            msg.should.equal('Stubbed Success 2');
-            return true;
-          });
-      });
+      it('should reject \'success\' method of obj with Error\'Stubbed Failure\' message',
+        function () {
+          return obj.success()
+            .catch(function (msg) {
+              msg.should.be.Error;
+              msg.message.should.equal('Stubbed Failure');
+              return BPromise.resolve(true);
+            });
+        });
 
-    it('should resolve \'syncronous\' method of obj with multiple values: \'Stubbed Success\'' +
-      ' and \'3\'',
-      function () {
-        return obj.syncronous()
-          .spread(function (msg, count) {
-            msg.should.equal('Stubbed Success');
-            count.should.equal(3);
-            return true;
-          });
-      });
+      it('should reject \'reject\' method of obj with Error \'Stubbed Failure 2\' message',
+        function () {
+          return obj.reject()
+            .catch(function (msg) {
+              msg.should.be.Error;
+              msg.message.should.equal('Stubbed Failure 2');
+              return BPromise.resolve(true);
+            });
+        });
 
-    after(function () {
-      //restore all the functions individually
-      obj.success.restore();
-      obj.reject.restore();
-      obj.syncronous.restore();
+      it('should reject \'syncronous\' method of obj with Error \'Stubbed Failure 3\' message',
+        function () {
+          return obj.syncronous()
+            .catch(function (msg) {
+              msg.should.be.Error;
+              msg.message.should.equal('Stubbed Failure 3');
+              return BPromise.resolve(true);
+            });
+        });
+
+      after(function () {
+        //restore all the functions
+        this.sandbox.restore();
+      });
     });
   });
 
-  describe('Reject stubs', function () {
-    before(function () {
-      //create a sinon sandbox to show how to easily restore funcs
-      this.sandbox = sinon.sandbox.create();
+  describe('Spies', function () {
 
-      //stub examples
-      this.sandbox.stub(obj, 'success').rejects(new Error('Stubbed Failure'));
-      this.sandbox.stub(obj, 'reject').rejects('Stubbed Failure 2');
-      this.sandbox.stub(obj, 'syncronous').rejects('Stubbed Failure 3');
+    var testMethods = {
+      successfulPromiseMethod: function (val, prom) {
+        return BPromise.resolve('Hello World!');
+      },
+      failedPromiseMethod: function (prom) {
+        return BPromise.reject('Good Bye World!');
+      },
+      pendingPromiseMethod: function (prom) {
+        return new BPromise(function (resolve, reject) {
+          return;
+        });
+      },
+    };
+
+    describe('returnedPromise', function () {
+      before(function () {
+        this.sandbox = sinon.sandbox.create();
+        this.spy = this.sandbox.spy(testMethods, 'successfulPromiseMethod');
+        this.spy2 = this.sandbox.spy(testMethods, 'failedPromiseMethod');
+        this.spy3 = this.sandbox.spy(testMethods, 'pendingPromiseMethod');
+        //execute the method
+        //Success
+        testMethods.successfulPromiseMethod();
+        //Failure
+        testMethods.failedPromiseMethod();
+        //Pending
+        testMethods.pendingPromiseMethod();
+      });
+
+      after(function () {
+        this.sandbox.restore();
+      });
+
+      it('should compare value to unwrapped promise value', function () {
+        this.spy.returnedPromise('Hello World!').should.be.true;
+        this.spy2.returnedPromise('Good Bye World!').should.be.true;
+      });
+
+      it('should throw if promise is still pending', function () {
+        this.spy3.returnedPromise.bind(this.spy3, 'Some Val')
+          .should.throw('Promise not resolved yet');
+      });
     });
 
-    it('should reject \'success\' method of obj with Error\'Stubbed Failure\' message',
-      function () {
-        return obj.success()
-          .catch(function (msg) {
-            msg.should.be.Error;
-            msg.message.should.equal('Stubbed Failure');
-            return BPromise.resolve(true);
-          });
+    describe('calledWithPromise', function () {
+      before(function () {
+        this.sandbox = sinon.sandbox.create();
+        this.spy = this.sandbox.spy(testMethods, 'successfulPromiseMethod');
+        this.spy2 = this.sandbox.spy(testMethods, 'failedPromiseMethod');
+        this.spy3 = this.sandbox.spy(testMethods, 'pendingPromiseMethod');
+        //execute the method
+        //Success
+        testMethods.successfulPromiseMethod('reg val', BPromise.resolve('Calling Promise'));
+        //Failure
+        testMethods.failedPromiseMethod(BPromise.reject('Calling Bad Promise'));
+        //Pending
+        testMethods.pendingPromiseMethod(new BPromise(function (rs, rj) {}));
       });
 
-    it('should reject \'reject\' method of obj with Error \'Stubbed Failure 2\' message',
-      function () {
-        return obj.reject()
-          .catch(function (msg) {
-            msg.should.be.Error;
-            msg.message.should.equal('Stubbed Failure 2');
-            return BPromise.resolve(true);
-          });
+      after(function () {
+        this.sandbox.restore();
       });
 
-    it('should reject \'syncronous\' method of obj with Error \'Stubbed Failure 3\' message',
-      function () {
-        return obj.syncronous()
-          .catch(function (msg) {
-            msg.should.be.Error;
-            msg.message.should.equal('Stubbed Failure 3');
-            return BPromise.resolve(true);
-          });
+      it('should compare value to unwrapped promise value', function () {
+        this.spy.calledWithPromise('reg val', 'Calling Promise').should.be.true;
+        this.spy2.calledWithPromise('Calling Bad Promise').should.be.true;
       });
 
-    after(function () {
-      //restore all the functions
-      this.sandbox.restore();
+      it('should throw if promise is still pending', function () {
+        this.spy3.calledWithPromise.bind(this.spy3, 'Some Val')
+          .should.throw('Promise not resolved yet');
+      });
+    });
+
+    describe('calledWithMatchPromise', function () {
+      before(function () {
+        this.sandbox = sinon.sandbox.create();
+        this.spy = this.sandbox.spy(testMethods, 'successfulPromiseMethod');
+        this.spy2 = this.sandbox.spy(testMethods, 'failedPromiseMethod');
+        this.spy3 = this.sandbox.spy(testMethods, 'pendingPromiseMethod');
+        //execute the method
+        //Success
+        testMethods.successfulPromiseMethod([], BPromise.resolve('Calling Promise'));
+        //Failure
+        testMethods.failedPromiseMethod(BPromise.reject({
+          name: 'Calling Bad Promise'
+        }));
+        //Pending
+        testMethods.pendingPromiseMethod(new BPromise(function (rs, rj) {}));
+      });
+
+      after(function () {
+        this.sandbox.restore();
+      });
+
+      it('should compare value type to unwrapped promise value type', function () {
+        this.spy.calledWithMatchPromise(Array, String).should.be.true;
+        this.spy2.calledWithMatchPromise(Object).should.be.true;
+      });
+
+      it('should throw if promise is still pending', function () {
+        this.spy3.calledWithMatchPromise.bind(this.spy3, Object)
+          .should.throw('Promise not resolved yet');
+      });
+    });
+
+    describe('calledWithExactlyPromise', function () {
+      before(function () {
+        this.sandbox = sinon.sandbox.create();
+        this.spy = this.sandbox.spy(testMethods, 'successfulPromiseMethod');
+        this.spy2 = this.sandbox.spy(testMethods, 'failedPromiseMethod');
+        this.spy3 = this.sandbox.spy(testMethods, 'pendingPromiseMethod');
+        //execute the method
+        //Success
+        testMethods.successfulPromiseMethod(['hello', 'world'], BPromise.resolve('Calling Promise'));
+        //Failure
+        testMethods.failedPromiseMethod(BPromise.reject({
+          name: 'Calling Bad Promise'
+        }));
+        //Pending
+        testMethods.pendingPromiseMethod(new BPromise(function (rs, rj) {}));
+      });
+
+      after(function () {
+        this.sandbox.restore();
+      });
+
+      it('should compare value type to unwrapped promise value type', function () {
+        this.spy.calledWithExactlyPromise(['hello', 'world'], 'Calling Promise').should.be.true;
+        this.spy2.calledWithExactlyPromise({
+          name: 'Calling Bad Promise'
+        }).should.be.true;
+      });
+
+      it('should throw if promise is still pending', function () {
+        this.spy3.calledWithExactlyPromise.bind(this.spy3, 'Some Val')
+          .should.throw('Promise not resolved yet');
+      });
     });
   });
 });


### PR DESCRIPTION
- added promise based methods on spies for testing promise values when
  passed in as function arguments
- added promise based methods on spies for testing promise values when
  they are returned from a function
- Test cases added
- See updated README file for examples and api docs
