### PR TITLE
support node 0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.2",
   "description": "Plugin that adds Bluebird Promise helper methods to Sinon.",
   "engines": {
-    "node": "0.10.x"
+    "node": ">=0.10 <0.13"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
sinon-bluebird seems to work with Node 0.12, so adding it to the allowed engines to get rid of the following npm warning at install time.

npm WARN engine sinon-bluebird@1.0.2: wanted: {"node":"0.10.x"} (current: {"node":"0.12.0","npm":"2.5.1"})
