### PR TITLE
Remove auto converting of string into Error object on ".rejects"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+2.0.0
+---
+- Removed auto conversion of string in the `.rejects` to Error. So now if you reject a string, the rejected value will remain a string
+
+1.1.1
+---
+- Added new helper methods for spies to auto unwrap any promise returned from a method or passed into a method. This allows directly comparing values rather than needing to manually unwrap them each time.
+
+1.0.0
+---
+- Initial release

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ sinon.stub(obj, 'foo').rejects('AHHHHHH!!!!');
 
 // Execute the stub function
 obj.foo().catch(function(e) {
-  // e === new Error('AHHHHHH!!!!')
+  // e === new Error('AHHHHHH!!!!') [<2.0.0]
+  // e === 'AHHHHHH!!!!' [>=2.0.0]
 });
 
 // Restore back to the original function
@@ -123,7 +124,7 @@ Returns a resolved bluebird promise with the given value
 
 Returns a rejected bluebird promise with the given value.
 
-*Note: If the given value is a String, that string will be wrapped in an Error object and will be on the message property.*
+*Note: If the given value is a String, that string will be wrapped in an Error object and will be on the message property.* **Depreciated in >=2.0.0**
 
 ### Spies
 
@@ -165,7 +166,7 @@ If you're wondering what the main differences are:
 - `sinon-as-promised` allows other promise libraries to be used instead of bluebird (`sinon-bluebird` is designed and optimized for use only with bluebird)
 - `sinon-as-promised` only supports `.then`, `.catch`, and `.finally` methods off of the stub (no special bluebird methods like: `.map`, `.bind`, `.spread`, etc...)
 
-## Contributers
+## Contributors
 
 - [Brian Moeskau](https://github.com/bmoeskau)
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Returns a resolved bluebird promise with the given value
 
 Returns a rejected bluebird promise with the given value.
 
-*Note: If the given value is a String, that string will be wrapped in an Error object and will be on the message property.* **Depreciated in >=2.0.0**
+*Note: If the given value is a String, that string will be wrapped in an Error object and will be on the message property.* **Removed in >=2.0.0**
 
 ### Spies
 

--- a/index.js
+++ b/index.js
@@ -26,12 +26,6 @@ Object.keys(BPromise.prototype).map(function (key) {
 // Create the rejects function
 function rejects(value) {
   this.rejectBPromise = true;
-
-  //if it's a string, wrap it in an error object
-  if (typeof value === "string") {
-    value = new Error(value);
-  }
-
   return this.returns(new RejectBPromise(value));
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sinon-bluebird",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Plugin that adds Bluebird Promise helper methods to Sinon.",
   "engines": {
     "node": ">=0.10 <0.13"

--- a/test/tests.js
+++ b/test/tests.js
@@ -80,7 +80,7 @@ describe('Sinon-Bluebird', function () {
         //stub examples
         this.sandbox.stub(obj, 'success').rejects(new Error('Stubbed Failure'));
         this.sandbox.stub(obj, 'reject').rejects('Stubbed Failure 2');
-        this.sandbox.stub(obj, 'synchronous').rejects('Stubbed Failure 3');
+        this.sandbox.stub(obj, 'synchronous').rejects(new Error('Stubbed Failure 3'));
       });
 
       it('should reject \'success\' method of obj with Error\'Stubbed Failure\' message',
@@ -97,8 +97,7 @@ describe('Sinon-Bluebird', function () {
         function () {
           return obj.reject()
             .catch(function (msg) {
-              msg.should.be.Error;
-              msg.message.should.equal('Stubbed Failure 2');
+              msg.should.equal('Stubbed Failure 2');
               return BPromise.resolve(true);
             });
         });


### PR DESCRIPTION
- Updated docs to reflect new change and depreciation notices
- Added a CHANGELOG file to better track changes
- Updated package version number
- Updated test cases

This should fix #8 
